### PR TITLE
Fix: Bulleted list and numbered lists switched!

### DIFF
--- a/src/resources/templates/editor.html
+++ b/src/resources/templates/editor.html
@@ -19,8 +19,8 @@
                     <button type="button" class="btn btn-default action-text-title-4" data-toggle="tooltip" data-placement="bottom" title="Heading 4 (<%= keyboardShortcut("ctrl-Alt-4") %>)">H4</button>
                 </div>
                 <div class="btn-group">
-                    <button type="button" class="btn btn-default action-text-list-ul"  data-toggle="tooltip" data-placement="bottom" title="Numbered List (<%= keyboardShortcut("ctrl-Alt-7") %>)"><i class="fa fa-list-ul"></i></button>
-                    <button type="button" class="btn btn-default action-text-list-ol"  data-toggle="tooltip" data-placement="bottom" title="Bulleted List (<%= keyboardShortcut("ctrl-Alt-8") %>)"><i class="fa fa-list-ol"></i></button>
+                    <button type="button" class="btn btn-default action-text-list-ul"  data-toggle="tooltip" data-placement="bottom" title="Bulleted List (<%= keyboardShortcut("ctrl-Alt-7") %>)"><i class="fa fa-list-ul"></i></button>
+                    <button type="button" class="btn btn-default action-text-list-ol"  data-toggle="tooltip" data-placement="bottom" title="Numbered List (<%= keyboardShortcut("ctrl-Alt-8") %>)"><i class="fa fa-list-ol"></i></button>
                     <button type="button" class="btn btn-default action-text-table"  data-toggle="tooltip" data-placement="bottom" title="Insert Table"><i class="fa fa-table"></i></button>
                 </div>
                 <div class="btn-group">


### PR DESCRIPTION
The label for the top icon for the unordered list was "Numbered List", when it should be "Bulleted List", when it should be the other way around. Same for "Bulleted List".
